### PR TITLE
character list is concatenated every time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Default: "0123456789"
 Define the string of specials chars. You must add some specials chars and set the parameter "special" to true if you want to use there's.
 Default: ""
 
+##### preserve
+Use the options that were defined in the previous call to increment/decrement
+Default: false
+
 ## Tests
 
   `npm test`

--- a/index.js
+++ b/index.js
@@ -8,31 +8,32 @@ module.exports = {
 };
 
 function init(options) {
+    if(!options.preserve) {
+        var settings = Object.assign({
+            alpha: true,
+            digit: true,
+            dashes: true,
+            specials: false,
+            orderby: "ALPHADIGIT",
 
-    var settings = Object.assign({
-        alpha: true,
-        digit: true,
-        dashes: true,
-        specials: false,
-        orderby: "ALPHADIGIT",
+            s_alpha: "abcdefghijklmnopqrstuvwxyz",
+            s_digit: "0123456789",
+            s_specials: "",
+        }, options);
 
-        s_alpha: "abcdefghijklmnopqrstuvwxyz",
-        s_digit: "0123456789",
-        s_specials: "",
-    }, options);
+        c = "";
 
-    c = "";
+        if (settings.orderby == "DIGITALPHA") {
+            if (settings.digit) c+= settings.s_digit;
+            if (settings.alpha) c+= settings.s_alpha;
+        } else {
+            if (settings.alpha) c+= settings.s_alpha;
+            if (settings.digit) c+= settings.s_digit;
+        }
 
-    if (settings.orderby == "DIGITALPHA") {
-        if (settings.digit) c+= settings.s_digit;
-        if (settings.alpha) c+= settings.s_alpha;
-    } else {
-        if (settings.alpha) c+= settings.s_alpha;
-        if (settings.digit) c+= settings.s_digit;
+        if (settings.dashes)    c+= "-";
+        if (settings.specials)  c+= settings.s_specials;
     }
-
-    if (settings.dashes)    c+= "-";
-    if (settings.specials)  c+= settings.s_specials;
 }
 
 function increment(str, options) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function init(options) {
         s_specials: "",
     }, options);
 
+    c = "";
 
     if (settings.orderby == "DIGITALPHA") {
         if (settings.digit) c+= settings.s_digit;


### PR DESCRIPTION
The character list appears to be concatenated on every call to `increment` or `decrement`.

```
> var increment = require('alphanum-increment').increment;
undefined
> increment('node09')
c= abcdefghijklmnopqrstuvwxyz0123456789-
'node0-'
> increment('node09', {dashes:false, alpha:false})
c= abcdefghijklmnopqrstuvwxyz0123456789-0123456789
'node1a'
> increment('node09', {dashes:false, alpha:false})
c= abcdefghijklmnopqrstuvwxyz0123456789-01234567890123456789
'node1a'
> increment('node09', {dashes:false, alpha:false})
c= abcdefghijklmnopqrstuvwxyz0123456789-012345678901234567890123456789
'node1a'
```

This pull request fixes that

```
> var increment = require('alphanum-increment').increment;
undefined
> increment('node09')
c= abcdefghijklmnopqrstuvwxyz0123456789-
'node0-'
> increment('node09', {dashes:false, alpha:false})
c= 0123456789
'node10'
> increment('node09', {dashes:false, alpha:false})
c= 0123456789
'node10'
> increment('node09', {dashes:false, alpha:false})
c= 0123456789
'node10'

```

and allows the option to preserve the previous settings

```
> var increment = require('alphanum-increment').increment;
undefined
> increment('node09', {dashes:false, alpha:false})
c= 0123456789
'node10'
> increment('node09', {preserve:true})
c= 0123456789
'node10'

```